### PR TITLE
setuptools minimum for python-3.12

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -14,3 +14,4 @@ uvicorn
 prettydate
 pytz
 pyramid_retry
+setuptools>=80.9.0


### PR DESCRIPTION
This is required for Python 3.12, since pip no longer installs setuptools by default.